### PR TITLE
Added a paragraph about building the docs locally.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,5 +4,9 @@ Thanks for taking the time to contribute.
 
 Any contribution to Agents.jl is welcome in the following ways:
 
-  * Modifying the code with a pull request
+  * Modifying the code or documentation with a pull request.
   * Reporting bugs and suggestions in the issues section of the project's Github.
+
+# Previewing Documentation Edits
+
+Modifications to the documentation can be previewed by building the documentation locally, which is made possible by a script located in docs/make.jl. The Documenter package is required and can be installed by running `import Pkg; Pkg.add("Documenter")` in a REPL session. Then the documentation can be built and previewed in build/ first by running `julia docs/make.jl` from a terminal.


### PR DESCRIPTION
In CONTRIBUTING.md, described how to build the documentation locally using the provided make.jl.